### PR TITLE
Add FormatBytes unit tests

### DIFF
--- a/ALTCommander.Tests/ALTCommander.Tests.csproj
+++ b/ALTCommander.Tests/ALTCommander.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Test.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ALTCommander\ALTCommander.csproj" />
+  </ItemGroup>
+</Project>

--- a/ALTCommander.Tests/FormatBytesTests.cs
+++ b/ALTCommander.Tests/FormatBytesTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace ALTCommander.Tests
+{
+    [TestClass]
+    public class FormatBytesTests
+    {
+        private static string InvokeAltCommanderForm(long bytes)
+        {
+            var type = typeof(AltCommander.AltCommanderForm);
+            var method = type.GetMethod("FormatBytes", BindingFlags.NonPublic | BindingFlags.Instance);
+            var instance = FormatterServices.GetUninitializedObject(type);
+            return (string)method.Invoke(instance, new object[] { bytes });
+        }
+
+        private static string InvokeDirectorySelectDialog(long bytes)
+        {
+            var type = typeof(ALTCommander.DirectorySelectDialog);
+            var method = type.GetMethod("FormatBytes", BindingFlags.NonPublic | BindingFlags.Instance);
+            var instance = FormatterServices.GetUninitializedObject(type);
+            return (string)method.Invoke(instance, new object[] { bytes });
+        }
+
+        [TestMethod]
+        public void AltCommanderForm_Returns_NA_For_Negative()
+        {
+            Assert.AreEqual("N/A", InvokeAltCommanderForm(-1));
+        }
+
+        [TestMethod]
+        public void AltCommanderForm_Returns_Zero_For_Zero()
+        {
+            Assert.AreEqual("0 B", InvokeAltCommanderForm(0));
+        }
+
+        [TestMethod]
+        public void AltCommanderForm_Scales_Correctly()
+        {
+            Assert.AreEqual("512 B", InvokeAltCommanderForm(512));
+            Assert.AreEqual("1 KB", InvokeAltCommanderForm(1024));
+            Assert.AreEqual("1.5 KB", InvokeAltCommanderForm(1536));
+            Assert.AreEqual("1 MB", InvokeAltCommanderForm(1048576));
+        }
+
+        [TestMethod]
+        public void DirectorySelectDialog_Returns_NA_For_Negative()
+        {
+            Assert.AreEqual("N/A", InvokeDirectorySelectDialog(-1));
+        }
+
+        [TestMethod]
+        public void DirectorySelectDialog_Returns_Zero_For_Zero()
+        {
+            Assert.AreEqual("0 B", InvokeDirectorySelectDialog(0));
+        }
+
+        [TestMethod]
+        public void DirectorySelectDialog_Scales_Correctly()
+        {
+            Assert.AreEqual("512 B", InvokeDirectorySelectDialog(512));
+            Assert.AreEqual("1 KB", InvokeDirectorySelectDialog(1024));
+            Assert.AreEqual("2 KB", InvokeDirectorySelectDialog(1536));
+            Assert.AreEqual("1 MB", InvokeDirectorySelectDialog(1048576));
+        }
+    }
+}

--- a/ALTCommander/ALTCommander.sln
+++ b/ALTCommander/ALTCommander.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ALTCommander", "ALTCommander.csproj", "{6027A1DB-805B-4D48-84D4-E258C3C346CE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ALTCommander.Tests", "..\ALTCommander.Tests\ALTCommander.Tests.csproj", "{7A2D671B-DB3F-4030-9347-8939E3D24E87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{6027A1DB-805B-4D48-84D4-E258C3C346CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6027A1DB-805B-4D48-84D4-E258C3C346CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6027A1DB-805B-4D48-84D4-E258C3C346CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6027A1DB-805B-4D48-84D4-E258C3C346CE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {6027A1DB-805B-4D48-84D4-E258C3C346CE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7A2D671B-DB3F-4030-9347-8939E3D24E87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7A2D671B-DB3F-4030-9347-8939E3D24E87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7A2D671B-DB3F-4030-9347-8939E3D24E87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7A2D671B-DB3F-4030-9347-8939E3D24E87}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ALTcommander
 Horizontal Split Dual-Screen File Manager.
+
+## Building
+
+Open `ALTCommander.sln` with Visual Studio. The solution now includes a test
+project `ALTCommander.Tests`. Build the solution or run `dotnet test
+ALTCommander.Tests/ALTCommander.Tests.csproj` to execute the unit tests.


### PR DESCRIPTION
## Summary
- add MSTest project `ALTCommander.Tests`
- test `FormatBytes` behaviour in both forms with reflection
- reference test project from solution
- document running tests in README

## Testing
- `dotnet test ALTCommander.Tests/ALTCommander.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840501020088333b01598df1c0ebc42