### PR TITLE
fix: use consistent namespace AltCommander

### DIFF
--- a/ALTCommander/ALTCommander.csproj
+++ b/ALTCommander/ALTCommander.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6027A1DB-805B-4D48-84D4-E258C3C346CE}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>ALTCommander</RootNamespace>
+    <RootNamespace>AltCommander</RootNamespace>
     <AssemblyName>ALTCommander</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/ALTCommander/Def_Key.Designer.cs
+++ b/ALTCommander/Def_Key.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ALTCommander
+﻿namespace AltCommander
 {
     partial class Def_Key
     {

--- a/ALTCommander/Def_Key.cs
+++ b/ALTCommander/Def_Key.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace ALTCommander
+namespace AltCommander
 {
     public partial class Def_Key : Form
     {

--- a/ALTCommander/DirectorySelectDialog.Designer.cs
+++ b/ALTCommander/DirectorySelectDialog.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ALTCommander
+﻿namespace AltCommander
 {
     partial class DirectorySelectDialog
     {

--- a/ALTCommander/DirectorySelectDialog.cs
+++ b/ALTCommander/DirectorySelectDialog.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace ALTCommander
+namespace AltCommander
 {
     public partial class DirectorySelectDialog : Form
     {


### PR DESCRIPTION
## Summary
- unify namespaces to `AltCommander`
- set `RootNamespace` to `AltCommander`

## Testing
- `dotnet build ALTCommander/ALTCommander.sln` *(fails: command not found)*
- `msbuild ALTCommander/ALTCommander.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840500c679083338f8c0847cb1a584b